### PR TITLE
Fixed a call to a deprecated function to obtain the MAC address

### DIFF
--- a/VP-CanBus-N2K_Interface-1.ino
+++ b/VP-CanBus-N2K_Interface-1.ino
@@ -80,7 +80,7 @@ void setup() {
   NMEA2000.SetN2kCANSendFrameBufSize(150);
 
 // Generate unique number from chip id
-  esp_efuse_read_mac(chipid);
+  esp_efuse_mac_get_default(chipid);
   for (i = 0; i < 6; i++) id += (chipid[i] << (7 * i));
 
 // Set product information


### PR DESCRIPTION
In release 4.0 of the Espressif IoT Development Framework the already deprecated function `system_efuse_read_mac()` was removed.
The new function to use is `esp_efuse_mac_get_default()`
This fixes it.

See [https://github.com/espressif/esp-idf/commit/bdeaf138c4c43314ce24309f800c366c2b754a45#diff-3c4f43c10183d428b17c5c895be8612d9e20f741bbaed37e28a8bf0bb8c7e009L261](https://github.com/espressif/esp-idf/commit/bdeaf138c4c43314ce24309f800c366c2b754a45#diff-3c4f43c10183d428b17c5c895be8612d9e20f741bbaed37e28a8bf0bb8c7e009L261)